### PR TITLE
Set default environment to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# For Sinatra configuration, defaults to production. 
+# For local development, set this value to development
+APP_ENV=production
+
 TWILIO_ACCOUNT_SID=
 TWILIO_API_KEY=
 TWILIO_API_SECRET=

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ Your application should now be running at [http://localhost:3000/](http://localh
 
 Check your config values, and then make sure everything looks good.
 
+### Configure Development vs Production Settings
+
+By default, this application will run in production mode - stack traces will not be visible in the web browser. If you would like to run this application in development locally, change the `APP_ENV` variable in your `.env` file.
+
+`APP_ENV=development`
+
+For more about development vs production, visit [Sinatra's configuration page](http://sinatrarb.com/configuration.html).
+
 ## Running the server with ngrok
 
 Your phone won't be able to access localhost directly. You'll need to create a

--- a/app.rb
+++ b/app.rb
@@ -7,7 +7,13 @@ require 'rack/parser'
 require_relative 'config_wrapper'
 require_relative 'sms_verify'
 
-ENV['RACK_ENV'] ||= 'development'
+# Load environment configuration
+Dotenv.load
+
+# Set the environment after dotenv loads
+# Default to production
+environment = (ENV['APP_ENV'] || ENV['RACK_ENV'] || :production).to_sym
+set :environment, environment
 
 module SmsVerification
   class App < Sinatra::Base

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 ENV['RACK_ENV'] = 'test'
+ENV['APP_ENV'] = 'test'
 ENV['CLIENT_SECRET'] = 'secret'
 
 require 'minitest/autorun'


### PR DESCRIPTION
Set default environment to production.

Changes in the PR:

- Set `APP_ENV` to `production`
- Update README.
